### PR TITLE
Fix error when clip names contain asterisks

### DIFF
--- a/lib/edl.rb
+++ b/lib/edl.rb
@@ -158,7 +158,7 @@ module EDL
   # EDL clip comment matcher, a generic one
   class CommentMatcher < Matcher
     def initialize
-      super(/\*(.+)/)
+      super(/^\*(.+)/)
     end
 
     def apply(stack, line)
@@ -184,7 +184,7 @@ module EDL
   # Clip name matcher
   class NameMatcher < Matcher
     def initialize
-      super(/\*\s*FROM CLIP NAME:(\s+)(.+)/)
+      super(/^\*\s*FROM CLIP NAME:(\s+)(.+)/)
     end
 
     def apply(stack, line)
@@ -195,7 +195,7 @@ module EDL
 
   class EffectMatcher < Matcher
     def initialize
-      super(/\*\s*EFFECT NAME:(\s+)(.+)/)
+      super(/^\*\s*EFFECT NAME:(\s+)(.+)/)
     end
 
     def apply(stack, line)

--- a/spec/lib/edl_spec.rb
+++ b/spec/lib/edl_spec.rb
@@ -521,6 +521,11 @@ describe EDL do
       line = '* COMMENT: PURE BULLSHIT'
       expect(EDL::CommentMatcher.new.matches?(line)).to be_truthy
     end
+    
+    it 'match a comment that that contains an asterisk' do
+      line = '* COMMENT: PURE *BULLSHIT*'
+      expect(EDL::CommentMatcher.new.matches?(line)).to be_truthy
+    end
 
     it 'apply the comment to the last clip on the stack' do
       line = '* COMMENT: PURE BULLSHIT'
@@ -578,6 +583,11 @@ describe EDL do
       line = '*FROM CLIP NAME:  TAPE_6-10.MOV'
       expect(EDL::NameMatcher.new.matches?(line)).to be_truthy
     end
+    
+    it 'match a clip name containing an asterisk' do
+      line = '* FROM CLIP NAME:  18B_1*'
+      expect(EDL::NameMatcher.new.matches?(line)).to be_truthy
+    end
 
     it 'not match a simple comment' do
       line = '* CRAP'
@@ -610,6 +620,11 @@ describe EDL do
 
     it 'match a dissolve name without space after the asterisk' do
       line = '*EFFECT NAME: CROSS DISSOLVE'
+      expect(EDL::EffectMatcher.new.matches?(line)).to be_truthy
+    end
+    
+    it 'match a dissolve name containing an asterisk' do
+      line = '* EFFECT NAME: *CROSS DISSOLVE'
       expect(EDL::EffectMatcher.new.matches?(line)).to be_truthy
     end
 

--- a/spec/lib/edl_spec.rb
+++ b/spec/lib/edl_spec.rb
@@ -452,6 +452,21 @@ describe EDL do
 
       expect('08:04:24:24'.tc).to eq clip.src_start_tc
     end
+    
+    it 'produce an Event when reel has asterisks' do
+      m = EDL::EventMatcher.new(25)
+      
+      clip = m.apply([],
+                    '047  *STUPID*EDITOR* V     C        00:00:38:15 00:00:39:08 01:06:37:03 01:06:37:20 ')
+      
+      expect(clip).to be_a(EDL::Event)
+      
+      expect('047').to eq clip.num
+      expect('*STUPID*EDITOR*').to eq clip.reel
+      expect('V').to eq clip.track
+      
+      expect('00:00:38:15'.tc).to eq clip.src_start_tc
+    end
 
     it 'produce an Event with dissolve' do
       m = EDL::EventMatcher.new(25)


### PR DESCRIPTION
Hey all, first pull request (ever), not sure about the etiquette. Apologies in advance.

I received an EDL where the clip names ended in an asterisk (*), which caused an error during parsing. I added a caret (^) to the regex pattern for the CommentMatcher, EffectMatcher, and NameMatcher so that it only matches when the line begins with an asterisk.

Example from the EDL that prompted this (offending events are 046 and 048):

> 046 A056C007 V     C        23:30:53:10 23:30:54:16 01:06:35:21 01:06:37:03 
>\* FROM CLIP NAME:  18B_1*
>\* SOURCE FILE: A056C007_170502_R1DC
>047  LRA_MT_Y V     C        00:00:38:15 00:00:39:08 01:06:37:03 01:06:37:20 
>\* FROM CLIP NAME:  500_1 WIFE 
>\* SOURCE FILE: LRA_MT_Y03UHD.MOV
>048  A056C007 V     C        23:30:54:23 23:30:55:18 01:06:37:20 01:06:38:15 
>\* FROM CLIP NAME:  18B_1* 
>\* SOURCE FILE: A056C007_170502_R1DC`